### PR TITLE
Prevent warning message

### DIFF
--- a/lib/Router/Simple/Reversible.pm
+++ b/lib/Router/Simple/Reversible.pm
@@ -30,7 +30,7 @@ ROUTE:
             !
                 if ($1) {
                     my ($name) = split /:/, $1, 2;
-                    $args->{$name};
+                    defined $args->{$name} ? $args->{$name} : '';
                 } elsif ($2) {
                     $args->{$2};
                 } elsif ($3) {

--- a/t/01_reversible.t
+++ b/t/01_reversible.t
@@ -28,4 +28,7 @@ is $router->path_for({ controller => 'Download', action => 'file' }, { splat => 
 is $router->path_for({ controller => 'NoSuchController', action => 'show' }),
    undef;
 
+is $router->path_for({ controller => 'Blog', action => 'monthly' }, { year => 2015 }),
+   '/blog/2015/';
+
 done_testing;


### PR DESCRIPTION
```perl
is $router->path_for({ controller => 'Blog', action => 'monthly' }, { year => 2015 }),
   '/blog/2015/';
```

In this case, Router::Simple::Reversible outputs warning message: `Use of uninitialized value in substitution iterator at lib/Router/Simple/Reversible.pm line 25.`
This pull request prevents warning message.